### PR TITLE
🚚 Rename to masq2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,24 @@
-# Masq OpenID Server
+# Masq2 OpenID Server
 
 [![Build Status](https://travis-ci.org/bardbess/masq.svg?branch=master)](http://travis-ci.org/bardbess/masq)
 
-Masq is a mountable Rails engine that provides OpenID server/identity provider functionality.
-It is the successor of the stand-alone Rails application [masquerade](http://github.com/dennisreimann/masquerade/).
+Masq2 is a mountable Rails engine that provides OpenID server/identity provider functionality.
+It is the successor to the [masq gem](https://github.com/dennisreimann/masq), which in turn
+was the successor of the stand-alone Rails application of the same purpose, [masquerade](http://github.com/dennisreimann/masquerade/).
 
-The project is released under the MIT-License and its source code is available at [GitHub](http://github.com/dennisreimann/masquerade/).
+Because of this history, and the desire to be drop-in compatible with `masq`,
+the namespace remains `Masq`, not `Masq2`.
+
+The project is released under the MIT-License and its source code is available at [GitHub](http://github.com/oauth-xx/masq2/).
 Feel free to fork and submit patches :)
 
 ## Installation
 
-0. In case you want to run masq as a standalone application (not integrated into an existing app), you will have to generate a barebone Rails app first:
+0. In case you want to run Masq2 as a standalone application (not integrated into an existing app), you will have to generate a bare-bone Rails app first:
     * `rails new my_openid_provider`
 
-1. Add masq to your Gemfile and install it:
-    * `gem 'masq'`
+1. Add `masq2` to your Gemfile and install it:
+    * `gem 'masq2'`
     * `bundle install`
 
 2. Copy the configuration and edit it:
@@ -56,7 +60,9 @@ client-server communication (like requesting simple registration data).
 
 ### Introduction
 
-This fork adds ORACLE database support to the existing dennisreimann/masq gem.
+`masq2` adds ORACLE database support, as well as support for 
+Rails 5.1, 5.2, 6.0, 6.1, 7.0, 7.1, 7.2, 8.0,
+which `masq` never had. 
 
 The main functionality is in the server controller, which is the endpoint for incoming
 OpenID requests. The server controller is supposed to only interact with relying parties

--- a/app/views/layouts/masq/base.html.erb
+++ b/app/views/layouts/masq/base.html.erb
@@ -60,8 +60,8 @@
     <div id="foot">
       <div class="wrap">
         <span class="note">
-          powered by <%= link_to 'masq', 'https://github.com/dennisreimann/masq' %>
-          and <%= link_to image_tag('masq/openid_symbol.png') + " OpenID", 'http://openid.net/' %> |
+          powered by <%= link_to 'masq', 'https://github.com/oauth-xx/masq2' %>
+          and <%= link_to image_tag('masq/openid_symbol.png') + " OpenID", 'https://openid.net/' %> |
           <%= link_to t(:get_help), help_path %>
         </span>
       </div>

--- a/app/views/layouts/masq/consumer.html.erb
+++ b/app/views/layouts/masq/consumer.html.erb
@@ -21,8 +21,8 @@
     <div id="foot">
       <div class="wrap">
         <span class="note">
-          powered by <%= link_to "masq", 'https://github.com/dennisreimann/masq' %>
-          and <%= link_to image_tag('masq/openid_symbol.png') + " OpenID", 'http://openid.net/' %>
+          powered by <%= link_to "masq", 'https://github.com/oauth-xx/masq2' %>
+          and <%= link_to image_tag('masq/openid_symbol.png') + " OpenID", 'https://openid.net/' %>
         </span>
       </div>
     </div>

--- a/lib/masq2.rb
+++ b/lib/masq2.rb
@@ -1,0 +1,1 @@
+require_relative "masq"

--- a/masq.gemspec
+++ b/masq.gemspec
@@ -5,13 +5,13 @@ require "masq/version"
 
 # Describe your gem and declare its dependencies:
 Gem::Specification.new do |s|
-  s.name        = "masq"
+  s.name        = "masq2"
   s.version     = Masq::VERSION
-  s.authors     = ["Dennis Reimann", "Bardoe Besselaar","Nikita Vasiliev"]
-  s.email       = ["mail@dennisreimann.de"]
-  s.homepage    = "https://github.com/bardbess/masq"
+  s.authors     = ["Peter Boling", "Dennis Reimann", "Bardoe Besselaar","Nikita Vasiliev"]
+  s.email       = ["peter.boling@gmail.com"]
+  s.homepage    = "https://github.com/oauth-xx/masq2"
   s.summary     = "Mountable Rails engine that provides OpenID server/identity provider functionality"
-  s.description = "Masq supports the current OpenID specifications (OpenID 2.0) and supports SReg, AX (fetch and store requests) and PAPE as well as some custom additions like multifactor authentication using a yubikey"
+  s.description = "Masq2 supports the current OpenID specifications (OpenID 2.0) and supports SReg, AX (fetch and store requests) and PAPE as well as some custom additions like multi-factor authentication using a yubikey"
 
   s.files = Dir["{app,config,db,lib}/**/*"] + ["MIT-LICENSE", "Rakefile", "README.md"]
   s.test_files = Dir["test/**/*"]


### PR DESCRIPTION
`masq` gem is now `masq2`, since no one has control of the `masq` gem namespace anymore.